### PR TITLE
Global events are firing on add/remove links pre-/post-execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add this line to your application's Gemfile:
 And then execute:
 
     $ bundle
-    
+
 In your application.js file add: 
 
     //= require nested_form_fields
@@ -39,7 +39,7 @@ Use the *nested_fields_for* helper inside your user form to add the video fields
       = f.nested_fields_for :videos do |ff|
         = ff.text_field :video_title
         ..
-  
+
 Links to add and remove fields can be added using the *add_nested_fields_link* and *remove_nested_fields_link* helpers:
 
     = form_for @user do |f|
@@ -48,8 +48,19 @@ Links to add and remove fields can be added using the *add_nested_fields_link* a
         = ff.text_field :video_title
         ..
       = f.add_nested_fields_link :videos
-      
+
 Note that *remove_nested_fields_link* needs to be called within the *nested_fields_for* call and *add_nested_fields_link* outside of it via the parent builder.
+There are 4 javascipt events firing before and after addition/removal of the fields in the *nested_form_fields* namespace. Namely:
+    fields_adding, fields_added, fields_removing, fields_removed
+
+CoffeeScript sample:
+
+    $(document).bind "fields_added.nested_form_fields", (event,param) ->
+        switch param.object_class
+            when "video"
+                console.log "Video object added"
+            else
+                console.log "INFO: Fields were successfully added, callback not handled."
 
 You can change the link text of *remove_nested_fields_link* and *add_nested_fields_link* like this:
 
@@ -62,8 +73,10 @@ You can change the type of the element wrapping the nested fields using the *wra
 
     = f.nested_fields_for :videos, wrapper_tag: :div do |ff|
 
-The default wrapper element is a fieldset.
-    
+The default wrapper element is a fieldset. To add legend element to the fieldset use:
+
+    = f.nested_fields_for :videos, legend: "Video" do |ff|
+
 
 ## Contributing
 
@@ -76,4 +89,5 @@ The default wrapper element is a fieldset.
 
 ## Contributers
 
-[Tom Riley](https://github.com/tomriley)
+- [Tom Riley](https://github.com/tomriley)
+- [Levente Tamas](https://github.com/tamisoft)

--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -26,13 +26,13 @@ module ActionView::Helpers
     def add_nested_fields_link association, text = nil
       @template.link_to text || "Add #{association.to_s.singularize.humanize}", '',
                         class: "add_nested_fields_link",
-                        data: { association_path: association_path(association.to_s) }
+                        data: { association_path: association_path(association.to_s), object_class: association.to_s.singularize }
     end
 
     def remove_nested_fields_link text = nil
       @template.link_to text || 'x', '',
                         class: "remove_nested_fields_link",
-                        data: { delete_association_field_name: delete_association_field_name }
+                        data: { delete_association_field_name: delete_association_field_name, object_class: @object.class.name.underscore.downcase }
     end
 
 

--- a/lib/nested_form_fields/version.rb
+++ b/lib/nested_form_fields/version.rb
@@ -1,3 +1,3 @@
 module NestedFormFields
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/vendor/assets/javascripts/nested_form_fields.js.coffee
+++ b/vendor/assets/javascripts/nested_form_fields.js.coffee
@@ -1,7 +1,11 @@
-bind_nested_forms_links = () ->
+window.nested_form_fields or= {}
+
+nested_form_fields.bind_nested_forms_links = () ->
   $('body').off("click", '.add_nested_fields_link')
   $('body').on 'click', '.add_nested_fields_link', ->
     $link = $(this)
+    object_class = $link.data('object-class')
+    $.event.trigger("fields_adding.nested_form_fields",{object_class: object_class});
     association_path = $link.data('association-path')
     $template = $("##{association_path}_template")
 
@@ -19,19 +23,23 @@ bind_nested_forms_links = () ->
       $child.replaceWith($("<script id='#{$child.attr('id')}' type='text/html' />").html($child.html()))
 
     $template.before( $parsed_template )
+    $.event.trigger("fields_added.nested_form_fields",{object_class: object_class});
     false
 
   $('body').off("click", '.remove_nested_fields_link')
   $('body').on 'click', '.remove_nested_fields_link', ->
     $link = $(this)
+    object_class = $link.data('object-class')
+    $.event.trigger("fields_removing.nested_form_fields",{object_class: object_class});
     delete_association_field_name = $link.data('delete-association-field-name')
     $nested_fields_container = $link.parents(".nested_fields").first()
     $nested_fields_container.before "<input type='hidden' name='#{delete_association_field_name}' value='1' />"
     $nested_fields_container.hide()
+    $.event.trigger("fields_removed.nested_form_fields",{object_class: object_class});
     false
 
 $(document).on "page:change", ->
-    bind_nested_forms_links()
+    nested_form_fields.bind_nested_forms_links()
 
 jQuery ->
-    bind_nested_forms_links()
+    nested_form_fields.bind_nested_forms_links()


### PR DESCRIPTION
Hey,
merge this if you think someone has a use besides me. This was a big help to me, because I was able to daisy chain events triggered after the fields were added. Like hiding elements and so on. I think it is useful when the code is purely event driven. I placed the events into global scope (though, with a very unique name, to avoid clashes), since you haven't established a namespace yet. :) If you are planning on one, then don't merge, since that'll break compatibility.

Usage:
$(document).bind( [EVENT],function(){} ) where EVENT is:
nested_forms:fields_adding -> fires before new fields are added
nested_forms:fields_added -> fires after new fields are added
nested_forms:fields_removing -> fires before fields are removed
nested_forms:fields_removed -> fires after fields are removed
