### PR TITLE
added ability to specify additional html attributes for add/remove links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ You can change the link text of *remove_nested_fields_link* and *add_nested_fiel
       ...
     f.add_nested_fields_link :videos, 'Add another funtastic video'
 
-You can add classes to the  *remove_nested_fields_link* and *add_nested_fields_link* like this:
+You can add classes/attributes to the  *remove_nested_fields_link* and *add_nested_fields_link* like this:
 
     ...
-      ff.remove_nested_fields_link 'Remove me', class: 'btn btn-danger'
+      ff.remove_nested_fields_link 'Remove me', class: 'btn btn-danger', role: 'button'
       ...
-    f.add_nested_fields_link :videos, 'Add another funtastic video', class: 'btn btn-primary'
+    f.add_nested_fields_link :videos, 'Add another funtastic video', class: 'btn btn-primary', role: 'button'
 
 You can change the type of the element wrapping the nested fields using the *wrapper_tag* option:
 

--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -23,16 +23,22 @@ module ActionView::Helpers
     end
 
 
-    def add_nested_fields_link association, text = nil, options = {}
-      @template.link_to text || "Add #{association.to_s.singularize.humanize}", '',
-                        class: "#{options[:class]} add_nested_fields_link",
-                        data: { association_path: association_path(association.to_s), object_class: association.to_s.singularize }
+    def add_nested_fields_link association, text = nil, html_options = {}
+      html_class = html_options.delete(:class) || {}
+      html_data = html_options.delete(:data) || {}
+      @template.link_to text || "Add #{association.to_s.singularize.humanize}", '', {
+                        class: "#{html_class} add_nested_fields_link",
+                        data: { association_path: association_path(association.to_s), object_class: association.to_s.singularize }.merge(html_data)
+                        }.merge(html_options)
     end
 
-    def remove_nested_fields_link text = nil, options = {}
-      @template.link_to text || 'x', '',
-                        class: "#{options[:class]} remove_nested_fields_link",
-                        data: { delete_association_field_name: delete_association_field_name, object_class: @object.class.name.underscore.downcase }
+    def remove_nested_fields_link text = nil, html_options = {}
+      html_class = html_options.delete(:class) || {}
+      html_data = html_options.delete(:data) || {}
+      @template.link_to text || 'x', '', {
+                        class: "#{html_class} remove_nested_fields_link",
+                        data: { delete_association_field_name: delete_association_field_name, object_class: @object.class.name.underscore.downcase }.merge(html_data)
+                        }.merge(html_options)
     end
 
 


### PR DESCRIPTION
This improves upon earlier commit that only allowed changing the "class" of the links. This mimics Rails' current "link_to" helper method better.