### PR TITLE
Trigger event on added element

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,18 @@ You can pass options like you would to the `content_tag` method by nesting them 
 There are 4 javascipt events firing before and after addition/removal of the fields in the *nested_form_fields* namespace. Namely:
     fields_adding, fields_added, fields_removing, fields_removed.
 
-CoffeeScript sample:
+The events fields_added and fields_removed are triggered on the element being added or removed. The events bubble up so you can listen for it on any parent element.
 
+CoffeeScript samples:
+
+    # Listen on an element
+    initializeSortable -> ($el)
+      $el.sortable(...)
+      $el.on 'fields_added.nested_form_fields', -> (event, param)
+        console.log event.target # The added field
+        console.log $(this)      # $el
+
+    # Listen on document
     $(document).on "fields_added.nested_form_fields", (event,param) ->
         switch param.object_class
             when "video"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ You can pass options like you would to the `content_tag` method by nesting them 
 There are 4 javascipt events firing before and after addition/removal of the fields in the *nested_form_fields* namespace. Namely:
     fields_adding, fields_added, fields_removing, fields_removed.
 
-The events fields_added and fields_removed are triggered on the element being added or removed. The events bubble up so you can listen for it on any parent element.
+The events fields_added and fields_removed are triggered on the element being added or removed. The events bubble up so you can listen for them on any parent element.
+This makes it easy to add listeners when you have multiple nested_form_fields on the same page.
 
 CoffeeScript samples:
 

--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -24,7 +24,7 @@ nested_form_fields.bind_nested_forms_links = () ->
       $child.replaceWith($("<script id='#{$child.attr('id')}' type='text/html' />").html($child.html()))
 
     $template.before( $parsed_template )
-    $.event.trigger("fields_added.nested_form_fields",{object_class: object_class, added_index: added_index, association_path: association_path});
+    $parsed_template.trigger("fields_added.nested_form_fields", {object_class: object_class, added_index: added_index, association_path: association_path});
     false
 
   $('body').off("click", '.remove_nested_fields_link')
@@ -38,7 +38,7 @@ nested_form_fields.bind_nested_forms_links = () ->
     $nested_fields_container.before "<input type='hidden' name='#{delete_association_field_name}' value='1' />"
     $nested_fields_container.hide()
     $nested_fields_container.find('input[required]:hidden').removeAttr('required')
-    $.event.trigger("fields_removed.nested_form_fields",{object_class: object_class, delete_association_field_name: delete_association_field_name, removed_index: removed_index});
+    $nested_fields_container.trigger("fields_removed.nested_form_fields",{object_class: object_class, delete_association_field_name: delete_association_field_name, removed_index: removed_index});
     false
 
 $(document).on "page:change", ->


### PR DESCRIPTION
Hi!

How about something like this? Since the events bubble up, it should be fully backwards compatible.

I only did it for `fields_added` and `fields_removed` since we don't have the element when the `fields_adding` fields_removing` are triggered (I think).

Fixes #30