### PR TITLE
Gemspec dependencies

### DIFF
--- a/nested_form_fields.gemspec
+++ b/nested_form_fields.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency 'rails', '>= 3.2.0'
+  gem.add_dependency 'coffee-rails', '~> 3.2.1'
+  gem.add_dependency 'jquery-rails'
 
-  gem.add_development_dependency 'jquery-rails'
   gem.add_development_dependency 'rspec-rails', '2.9.0'
   gem.add_development_dependency 'assert_difference'
   gem.add_development_dependency 'capybara'
@@ -28,5 +29,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'haml', '>= 3.1.5'
   gem.add_development_dependency 'haml-rails'
   gem.add_development_dependency 'sass-rails', '~> 3.2.3'
-  gem.add_development_dependency 'coffee-rails', '~> 3.2.1'
 end


### PR DESCRIPTION
Both coffee-rails and jquery-rails are required to be able to run in a Rails app... this should be enforced by the dependencies specified in the file.