### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 rvm:
-  - 2.1.3
+  - 1.9.3
+  - 2.0.0
+  - 2.1.7
+  - 2.2.3
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-ruby '2.1.3'
-
 # Specify your gem's dependencies in nested_form_fields.gemspec
 gemspec

--- a/nested_form_fields.gemspec
+++ b/nested_form_fields.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Nico Ritsche"]
   gem.email         = ["ncrdevmail@gmail.com"]
   gem.description   = %q{Rails gem for dynamically adding and removing nested has_many association fields in a form.
-                         Uses jQuery and supports multiple nesting levels. Requires Ruby 1.9 and the asset pipeline.}
+                         Uses jQuery and supports multiple nesting levels. Requires Ruby 1.9+ and the asset pipeline.}
   gem.summary       = %q{Rails gem for dynamically adding and removing nested has_many association fields in a form.}
   gem.homepage      = ""
 
@@ -29,4 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'haml', '>= 3.1.5'
   gem.add_development_dependency 'haml-rails'
   gem.add_development_dependency 'sass-rails', '~> 3.2.3'
+  gem.add_development_dependency 'test-unit', '1.2.3'
 end


### PR DESCRIPTION
I added in some automated testing for the following versions of Ruby:

- 1.9.3
- 2.0.0
- 2.1.7
- 2.2.3

Ruby 2.2+ required the `test-unit` gem to be included. All the other versions built without a problem. Thanks!