### PR TITLE
Do not require class_name for namespaced associations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rvm:
   - 2.0.0
   - 2.1.7
   - 2.2.3
+
+before_install: gem install bundler -v 1.11.2 
+
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -97,7 +97,7 @@ module ActionView::Helpers
                              class: for_template ? 'form_template' : nil,
                              style: for_template ? 'display:none' : nil ) do
         nested_fields_wrapper(association_name, options[:wrapper_tag], options[:legend], options[:wrapper_options]) do
-          association_class = (options[:class_name] || association_name).to_s.classify.constantize
+          association_class = (options[:class_name] || object.public_send(association_name).klass.name).to_s.classify.constantize
           fields_for_nested_model("#{name}[#{index_placeholder(association_name)}]",
                                    association_class.new,
                                    options.merge(for_template: true), block)


### PR DESCRIPTION
We can determine association class name from the association itself, so you don't need to specify class_name for namespaced association. This is more DRY.

Works for me, though I'd like to hear any feedback. 

There is a strange error on travis when it's running bundle install. I have no idea what's wrong. Probably not related to this change