### PR TITLE
Turbolinks 5 compatibility

### DIFF
--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -53,7 +53,7 @@ nested_form_fields.bind_nested_forms_links = () ->
     $nested_fields_container.trigger("fields_removed.nested_form_fields",{object_class: object_class, delete_association_field_name: delete_association_field_name, removed_index: removed_index});
     false
 
-$(document).on "page:change", ->
+$(document).on "page:change turbolinks:load", ->
     nested_form_fields.bind_nested_forms_links()
 
 jQuery ->


### PR DESCRIPTION
As far as I can see this is the only required change to make nested_form_fields work with turbolinks 5. Tested on both versions