### PR TITLE
Changes to allow for a magic index replacement variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ $(document).on "fields_added.nested_form_fields", (event, param) ->
       console.log "INFO: Fields were successfully added, callback not handled."
 ```
 
+## Index replacement string
+
+Sometimes your code needs to know what index it has when it is instantiated onto the page.   
+HTML data elements may need point to other form elements for instance.   This is needed for integration
+with rails3-jquery-autocomplete.  
+
+To enable string substitution with the current index use the magic string '__nested_field_for_replace_with_index__'
 
 ## Contributing
 

--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -19,6 +19,8 @@ nested_form_fields.bind_nested_forms_links = () ->
     # insert association indexes
     index_placeholder = "__#{association_path}_index__"
     template_html = template_html.replace(new RegExp(index_placeholder,"g"), added_index)
+	# look for replacements in user defined code and substitute with the index
+    template_html = template_html.replace(new RegExp("__nested_field_for_replace_with_index__","g"), added_index)
 
     # replace child template div tags with script tags to avoid form submission of templates
     $parsed_template = $(template_html)

--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -69,13 +69,15 @@ module ActionView::Helpers
       end
 
       output = ActiveSupport::SafeBuffer.new
-      association.each do |child|
+      association.each_with_index do |child, index|
         wrapper_options = options[:wrapper_options].clone || {}
         if child._destroy == true
           wrapper_options[:style] = wrapper_options[:style] ? wrapper_options[:style] + ';' + 'display:none' : 'display:none'
         end
         output << nested_fields_wrapper(association_name, options[:wrapper_tag], options[:legend], wrapper_options) do
-          fields_for_nested_model("#{name}[#{options[:child_index] || nested_child_index(name)}]", child, options, block)
+          new_block = fields_for_nested_model("#{name}[#{options[:child_index] || nested_child_index(name)}]", child, options, block)
+          # do substitution in user defined blocks with the current index allows JS functions to have proper references
+          new_block.gsub('__nested_field_for_replace_with_index__', index.to_s).html_safe
         end
       end
 


### PR DESCRIPTION
I wanted to use nested_form_fields with rails3-jquery-autocomplete which uses a "data" attribute on the autocomplete field to specify which hidden field to store the selected autocompleted id.   Since the id of the hidden field changes based on the number of elements it doesn't work.    By adding a magic replacement string I am able to accurately target the hidden field and autocomplete will now work with nested_form_fields.

I'm happy to implement something different if you have a better idea on how to solve this problem.

BTW- rails4-autocomplete appears to require the same functionality.