### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Sometimes your code needs to know what index it has when it is instantiated onto
 HTML data elements may need point to other form elements for instance.   This is needed for integration
 with rails3-jquery-autocomplete.  
 
-To enable string substitution with the current index use the magic string '__nested_field_for_replace_with_index__'
+To enable string substitution with the current index use the magic string '\__nested_field_for_replace_with_index\__'
 
 ## Contributing
 


### PR DESCRIPTION
Sorry, I made a documentation formatting mistake.   The two underscores in front and behind the 'nested_field_for_replace_with_index' are being interpreted as BOLD instead of as two underscores.   I escaped them to correct the problem.