### PR TITLE
Use html5 template tag instead of script/div hack

### DIFF
--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -22,12 +22,7 @@ nested_form_fields.bind_nested_forms_links = () ->
 	# look for replacements in user defined code and substitute with the index
     template_html = template_html.replace(new RegExp("__nested_field_for_replace_with_index__","g"), added_index)
 
-    # replace child template div tags with script tags to avoid form submission of templates
     $parsed_template = $(template_html)
-    $child_templates = $parsed_template.closestChild('.form_template')
-    $child_templates.each () ->
-      $child = $(this)
-      $child.replaceWith($("<script id='#{$child.attr('id')}' type='text/html' />").html($child.html()))
 
     if target?
       $('#' + target).append($parsed_template)

--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -87,24 +87,12 @@ module ActionView::Helpers
 
 
     def nested_model_template name, association_name, options, block
-      for_template = self.options[:for_template]
-
-      # Render the outermost template in a script tag to avoid it from being submited with the form
-      # Render all deeper nested templates as hidden divs as nesting script tags messes up the html.
-      # When nested fields are added with javascript by using a template that contains nested templates,
-      # the outermost nested templates div's are replaced by script tags to prevent those nested templates
-      # fields from form subission.
-      #
-      @template.content_tag( for_template ? :div : :script,
-                             type: for_template ? nil : 'text/html',
-                             id: template_id(association_name),
-                             class: for_template ? 'form_template' : nil,
-                             style: for_template ? 'display:none' : nil ) do
+      @template.content_tag( :template, id: template_id(association_name)) do
         nested_fields_wrapper(association_name, options[:wrapper_tag], options[:legend], options[:wrapper_options]) do
           association_class = (options[:class_name] || object.public_send(association_name).klass.name).to_s.classify.constantize
           fields_for_nested_model("#{name}[#{index_placeholder(association_name)}]",
                                    association_class.new,
-                                   options.merge(for_template: true), block)
+                                   options, block)
         end
       end
     end


### PR DESCRIPTION
I ran into [this issue](https://github.com/ncri/nested_form_fields/issues/46) on a project I'm currently working on when using ckeditor in a nested field.

This PR gets rid of the script/div hack in favour of HTML5's `<template>` tag. This works well for us as we don't need to target IE, but I'm not sure how suitable you'd find it for merging upstream. The browser support isn't too great: http://caniuse.com/#feat=template

That said, there are numerous polyfills that could be used alongside the changes here. The only thing I'd be concerned about with those is whether they block execution of any `<script>` tags inside the `<template>`. I've not had chance to test this out yet. Perhaps it would make sense to add an option to `nested_fields_for` to opt-in to `<template>`?

Also had a quick look through the open issues, and I believe it would also fix https://github.com/ncri/nested_form_fields/issues/63.