### PR TITLE
Fix bug where form builder crashes with Symbol object_name

### DIFF
--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -115,7 +115,7 @@ module ActionView::Helpers
     end
 
     def association_path association_name
-      "#{object_name.gsub('][','_').gsub(/_attributes/,'').sub('[','_').sub(']','')}_#{association_name}"
+      "#{object_name.to_s.gsub('][','_').gsub(/_attributes/,'').sub('[','_').sub(']','')}_#{association_name}"
     end
 
     def index_placeholder association_name


### PR DESCRIPTION
Sometimes the object we're building a form for has a Symbol as an object_name in the form builder (rather than a String). In particular, I was trying to use nested_form_fields on a User object created by Devise, which sets the object_name to `:user`.

Calling gsub on Symbol results in a NoMethodError. Quick fix here.
