### PR TITLE
Allow gsub replace of __nested_field_for_replace_with_index__ in wrapper as well as user fields

### DIFF
--- a/lib/nested_form_fields.rb
+++ b/lib/nested_form_fields.rb
@@ -75,11 +75,12 @@ module ActionView::Helpers
           wrapper_options[:style] = wrapper_options[:style] ? wrapper_options[:style] + ';' + 'display:none' : 'display:none'
           output << destroy_hidden_field(association_name, index)
         end
-        output << nested_fields_wrapper(association_name, options[:wrapper_tag], options[:legend], wrapper_options) do
-          new_block = fields_for_nested_model("#{name}[#{options[:child_index] || nested_child_index(name)}]", child, options, block)
-          # do substitution in user defined blocks with the current index allows JS functions to have proper references
-          new_block.gsub('__nested_field_for_replace_with_index__', index.to_s).html_safe
+
+        # Build the wrapper + content and do substitution with the current index allows JS functions to have proper references
+        wrapped_block = nested_fields_wrapper(association_name, options[:wrapper_tag], options[:legend], wrapper_options) do
+          fields_for_nested_model("#{name}[#{options[:child_index] || nested_child_index(name)}]", child, options, block)
         end
+        output << wrapped_block.gsub('__nested_field_for_replace_with_index__', index.to_s).html_safe
       end
 
       output << nested_model_template(name, association_name, options, block)


### PR DESCRIPTION
At present it's not possible to include __nested_field_for_replace_with_index__ in the wrapper of a set of fields. 

ie:
<%= f.nested_fields_for :service_system_guide_pages, wrapper_tag: :div, wrapper_options: { class: 'panel', 'data-id': '__nested_field_for_replace_with_index__' } do | ff | %>
***snip***

This PR moves the gsub up one extra level to allow this to be processed.

(cherry picked from commit b4b5d52)