### PR TITLE
Do not remove nested field on disabled link click

### DIFF
--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -40,6 +40,7 @@ nested_form_fields.bind_nested_forms_links = () ->
   $('body').on 'click', '.remove_nested_fields_link', ->
     $link = $(this)
     return false unless $.rails == undefined || $.rails.allowAction($link)
+    return false if $link.attr('disabled')
     object_class = $link.data('object-class')
     delete_association_field_name = $link.data('delete-association-field-name')
     removed_index = parseInt(delete_association_field_name.match('(\\d+\\]\\[_destroy])')[0].match('\\d+')[0])


### PR DESCRIPTION
This prevents removing the nested field when its removal link is generated through something like:

    = ff.remove_nested_fields_link disabled: true