### PR TITLE
Add support for new 'Turbo' gem, a replacement for TurboLinks

### DIFF
--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -56,10 +56,7 @@ nested_form_fields.bind_nested_forms_links = () ->
     $nested_fields_container.trigger("fields_removed.nested_form_fields",{object_class: object_class, delete_association_field_name: delete_association_field_name, removed_index: removed_index});
     false
 
-$(document).on "page:change turbolinks:load", ->
-    nested_form_fields.bind_nested_forms_links()
-
-$(document).on "page:change turbo:load", ->
+$(document).on "page:change turbolinks:load turbo:load turbo:render", ->
     nested_form_fields.bind_nested_forms_links()
 
 jQuery ->

--- a/lib/assets/javascripts/nested_form_fields.js.coffee
+++ b/lib/assets/javascripts/nested_form_fields.js.coffee
@@ -59,6 +59,9 @@ nested_form_fields.bind_nested_forms_links = () ->
 $(document).on "page:change turbolinks:load", ->
     nested_form_fields.bind_nested_forms_links()
 
+$(document).on "page:change turbo:load", ->
+    nested_form_fields.bind_nested_forms_links()
+
 jQuery ->
     nested_form_fields.bind_nested_forms_links()
 


### PR DESCRIPTION
This small code change adds support the Turbo gem in a very similar way to the TurboLinks gem.  

This is a solution for ISSUE 114
https://github.com/ncri/nested_form_fields/issues/114